### PR TITLE
Use unstable_noStore for cache invalidation

### DIFF
--- a/database/connect.ts
+++ b/database/connect.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { headers } from 'next/headers';
+import { unstable_noStore as noStore } from 'next/cache';
 import postgres, { Sql } from 'postgres';
 import { setEnvironmentVariables } from '../util/config.mjs';
 
@@ -38,7 +38,7 @@ function connectOneTimeToDatabase() {
   return ((
     ...sqlParameters: Parameters<typeof globalThis.postgresSqlClient>
   ) => {
-    headers();
+    noStore();
     return globalThis.postgresSqlClient(...sqlParameters);
   }) as typeof globalThis.postgresSqlClient;
 }

--- a/database/connect.ts
+++ b/database/connect.ts
@@ -22,19 +22,14 @@ function connectOneTimeToDatabase() {
     });
   }
 
-  // Workaround to force Next.js Dynamic Rendering:
+  // Use Next.js Dynamic Rendering in all database queries:
   //
-  // Wrap sql`` tagged template function to call `headers()` from
-  // next/headers before each database query. `headers()` is a
+  // Wrap sql`` tagged template function to call `noStore()` from
+  // next/cache before each database query. `noStore()` is a
   // Next.js Dynamic Function, which causes the page to use
-  // Dynamic Rendering.
+  // Dynamic Rendering
   //
   // https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic-rendering
-  //
-  // Ideally there would something built into Next.js for this,
-  // which has been requested here:
-  //
-  // https://github.com/vercel/next.js/discussions/50695
   return ((
     ...sqlParameters: Parameters<typeof globalThis.postgresSqlClient>
   ) => {


### PR DESCRIPTION
Replace the next.js `headers()` with the new `unstable_noStore()` that has been tested to be working and works the same as `headers()` but doesn't return any value.

https://nextjs.org/docs/app/api-reference/functions/unstable_noStore