### PR TITLE
Fix SQL Formatter keyword capitalisation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,7 @@
     "postcss",
     "javascript",
     "typescriptreact"
-  ]
+  ],
+  // Disable comment formatting on save from Rewrap VS Code extension
+  "rewrap.onSave": false
 }

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -74,7 +74,7 @@ export const createAnimal = cache(
       INSERT INTO
         animals (
           first_name,
-          TYPE,
+          type,
           accessory
         )
       VALUES
@@ -97,8 +97,8 @@ export const updateAnimalById = cache(
       UPDATE animals
       SET
         first_name = ${firstName},
-      TYPE = ${type},
-      accessory = ${accessory || null}
+        type = ${type},
+        accessory = ${accessory || null}
       WHERE
         id = ${id}
       RETURNING

--- a/migrations/00000-createTableAnimal.ts
+++ b/migrations/00000-createTableAnimal.ts
@@ -10,14 +10,13 @@ export type Animal = {
 
 export async function up(sql: Sql) {
   await sql`
-    CREATE TABLE
-      animals (
-        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        first_name VARCHAR(30) NOT NULL,
-        TYPE VARCHAR(30) NOT NULL,
-        accessory VARCHAR(30),
-        birth_date DATE NOT NULL
-      );
+    CREATE TABLE animals (
+      id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+      first_name VARCHAR(30) NOT NULL,
+      type VARCHAR(30) NOT NULL,
+      accessory VARCHAR(30),
+      birth_date DATE NOT NULL
+    );
   `;
 }
 

--- a/migrations/00001-insertAnimals.ts
+++ b/migrations/00001-insertAnimals.ts
@@ -44,7 +44,7 @@ export async function up(sql: Sql) {
       INSERT INTO
         animals (
           first_name,
-          TYPE,
+          type,
           accessory,
           birth_date
         )

--- a/migrations/00002-createTableFoods.ts
+++ b/migrations/00002-createTableFoods.ts
@@ -2,12 +2,11 @@ import { Sql } from 'postgres';
 
 export async function up(sql: Sql) {
   await sql`
-    CREATE TABLE
-      foods (
-        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        NAME VARCHAR(30) NOT NULL,
-        TYPE VARCHAR(30) NOT NULL
-      )
+    CREATE TABLE foods (
+      id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+      name VARCHAR(30) NOT NULL,
+      type VARCHAR(30) NOT NULL
+    )
   `;
 }
 

--- a/migrations/00003-insertFoods.ts
+++ b/migrations/00003-insertFoods.ts
@@ -19,8 +19,8 @@ export async function up(sql: Sql) {
     await sql`
       INSERT INTO
         foods (
-          NAME,
-          TYPE
+          name,
+          type
         )
       VALUES
         (

--- a/migrations/00004-createTableAnimalFoods.ts
+++ b/migrations/00004-createTableAnimalFoods.ts
@@ -23,12 +23,11 @@ export type AnimalWithFoodsInJsonAgg = {
 
 export async function up(sql: Sql) {
   await sql`
-    CREATE TABLE
-      animal_foods (
-        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        animal_id INTEGER NOT NULL REFERENCES animals (id) ON DELETE CASCADE,
-        food_id INTEGER NOT NULL REFERENCES foods (id)
-      )
+    CREATE TABLE animal_foods (
+      id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+      animal_id INTEGER NOT NULL REFERENCES animals (id) ON DELETE CASCADE,
+      food_id INTEGER NOT NULL REFERENCES foods (id)
+    )
   `;
 }
 

--- a/migrations/00006-createTableUsers.ts
+++ b/migrations/00006-createTableUsers.ts
@@ -7,12 +7,11 @@ export type User = {
 
 export async function up(sql: Sql) {
   await sql`
-    CREATE TABLE
-      users (
-        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        username VARCHAR(80) NOT NULL UNIQUE,
-        password_hash VARCHAR(80) NOT NULL
-      );
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+      username VARCHAR(80) NOT NULL UNIQUE,
+      password_hash VARCHAR(80) NOT NULL
+    );
   `;
 }
 

--- a/migrations/00007-createTableSessions.ts
+++ b/migrations/00007-createTableSessions.ts
@@ -8,13 +8,12 @@ export type Session = {
 
 export async function up(sql: Sql) {
   await sql`
-    CREATE TABLE
-      sessions (
-        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        token VARCHAR(150) NOT NULL UNIQUE,
-        expiry_timestamp TIMESTAMP NOT NULL DEFAULT NOW() + INTERVAL '24 hours',
-        user_id INTEGER NOT NULL REFERENCES users (id) ON DELETE CASCADE
-      );
+    CREATE TABLE sessions (
+      id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+      token VARCHAR(150) NOT NULL UNIQUE,
+      expiry_timestamp TIMESTAMP NOT NULL DEFAULT NOW() + INTERVAL '24 hours',
+      user_id INTEGER NOT NULL REFERENCES users (id) ON DELETE CASCADE
+    );
   `;
 }
 

--- a/migrations/00008-createTableNotes.ts
+++ b/migrations/00008-createTableNotes.ts
@@ -8,12 +8,11 @@ export type Note = {
 
 export async function up(sql: Sql) {
   await sql`
-    CREATE TABLE
-      notes (
-        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-        user_id INTEGER NOT NULL REFERENCES users (id) ON DELETE CASCADE,
-        text_content TEXT NOT NULL
-      );
+    CREATE TABLE notes (
+      id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+      user_id INTEGER NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+      text_content TEXT NOT NULL
+    );
   `;
 }
 

--- a/package.json
+++ b/package.json
@@ -44,5 +44,10 @@
     "stylelint": "^15.10.3",
     "stylelint-config-upleveled": "^1.0.2",
     "typescript": "^5.2.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "sql-formatter": "15.0.2"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  sql-formatter: 15.0.2
+
 dependencies:
   '@testing-library/jest-dom':
     specifier: ^6.1.3
@@ -8081,7 +8084,7 @@ packages:
       jsox: 1.2.118
       node-sql-parser: 4.11.0
       prettier: 3.0.3
-      sql-formatter: 14.0.0
+      sql-formatter: 15.0.2
       tslib: 2.6.2
     dev: true
 
@@ -8973,10 +8976,10 @@ packages:
         integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
       }
 
-  /sql-formatter@14.0.0:
+  /sql-formatter@15.0.2:
     resolution:
       {
-        integrity: sha512-VcHYMRvZqg3RNjjxNB/puT9O1hR5QLXTvgTaBtxXcvmRQwSnH9M+oW2Ti+uFuVVU8HoNlOjU2uKHv8c0FQNsdQ==,
+        integrity: sha512-B8FTRc1dhb36lfuwSdiLhwrhkvT3PU/3es7YDPPQBOhbGHdXKlweAXTRS+QfCWk06ufAh118yFja6NcukBS4gg==,
       }
     hasBin: true
     dependencies:


### PR DESCRIPTION
Using SQL Formatter was causing issues with incorrect capitalising keywords like `TYPE` and `NAME`. Upgrading the SQL Formatter version to `15.0.2` fixes these issues.