### PR TITLE
Display birth date on naive management pages

### DIFF
--- a/app/animal-management-naive-dont-copy/create/page.tsx
+++ b/app/animal-management-naive-dont-copy/create/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation';
 import { createAnimal } from '../../../database/animals';
+import { formatDate } from '../../../util/dates';
 
 export const metadata = {
   description: 'Create a new animal',
@@ -10,6 +11,7 @@ type Props = {
     firstName: string;
     type: string;
     accessory: string;
+    birthDate: string;
   };
 };
 
@@ -30,6 +32,7 @@ export default async function NaiveCreateAnimalPage(props: Props) {
       <p>has been created with the following information</p>
       <p>Type: {animal.type}</p>
       <p>Accessory: {animal.accessory}</p>
+      <p>Birth date: {formatDate(animal.birthDate)}</p>
     </div>
   );
 }

--- a/app/animal-management-naive-dont-copy/create/page.tsx
+++ b/app/animal-management-naive-dont-copy/create/page.tsx
@@ -11,7 +11,6 @@ type Props = {
     firstName: string;
     type: string;
     accessory: string;
-    birthDate: string;
   };
 };
 

--- a/app/animal-management-naive-dont-copy/read/[animalId]/page.tsx
+++ b/app/animal-management-naive-dont-copy/read/[animalId]/page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
 import { getAnimalById } from '../../../../database/animals';
+import { formatDate } from '../../../../util/dates';
 
 export async function generateMetadata(props: Props) {
   const singleAnimal = await getAnimalById(Number(props.params.animalId));
@@ -33,7 +34,8 @@ export default async function NaiveAnimalPage(props: Props) {
         height={200}
         alt={singleAnimal.firstName}
       />
-      this is a {singleAnimal.type} carrying {singleAnimal.accessory}
+      this is a {singleAnimal.type} carrying {singleAnimal.accessory} with a
+      birth date of {formatDate(singleAnimal.birthDate)}
     </div>
   );
 }

--- a/app/animal-management-naive-dont-copy/read/[animalId]/page.tsx
+++ b/app/animal-management-naive-dont-copy/read/[animalId]/page.tsx
@@ -28,14 +28,14 @@ export default async function NaiveAnimalPage(props: Props) {
     <div>
       This is a single animal page
       <h1>{singleAnimal.firstName}</h1>
+      <div>Birth date: {formatDate(singleAnimal.birthDate)}</div>
       <Image
         src={`/images/${singleAnimal.firstName.toLowerCase()}.png`}
         width={200}
         height={200}
         alt={singleAnimal.firstName}
       />
-      this is a {singleAnimal.type} carrying {singleAnimal.accessory} with a
-      birth date of {formatDate(singleAnimal.birthDate)}
+      this is a {singleAnimal.type} carrying {singleAnimal.accessory}
     </div>
   );
 }

--- a/app/animal-management-naive-dont-copy/read/page.tsx
+++ b/app/animal-management-naive-dont-copy/read/page.tsx
@@ -17,7 +17,9 @@ export default async function NaiveAnimalsPage() {
       {animals.map((animal) => {
         return (
           <div key={`animal-div-${animal.id}`}>
-            <Link href={`/animals/${animal.id}`}>{animal.firstName}</Link>
+            <Link href={`/animal-management-naive-dont-copy/read/${animal.id}`}>
+              {animal.firstName}
+            </Link>
             <Image
               src={`/images/${animal.firstName.toLowerCase()}.png`}
               alt={animal.firstName}

--- a/app/animal-management-naive-dont-copy/update/[animalId]/page.tsx
+++ b/app/animal-management-naive-dont-copy/update/[animalId]/page.tsx
@@ -9,18 +9,16 @@ type Props = {
     firstName: string;
     type: string;
     accessory: string;
-    birthDate: string;
   };
 };
 
 export default async function NaiveAnimalUpdatePage(props: Props) {
-  const animal = await updateAnimalById({
-    id: Number(props.params.animalId),
-    firstName: props.searchParams.firstName,
-    type: props.searchParams.type,
-    accessory: props.searchParams.accessory || null,
-    birthDate: new Date(props.searchParams.birthDate),
-  });
+  const animal = await updateAnimalById(
+    Number(props.params.animalId),
+    props.searchParams.firstName,
+    props.searchParams.type,
+    props.searchParams.accessory,
+  );
 
   if (!animal) {
     notFound();

--- a/app/animal-management-naive-dont-copy/update/[animalId]/page.tsx
+++ b/app/animal-management-naive-dont-copy/update/[animalId]/page.tsx
@@ -9,16 +9,18 @@ type Props = {
     firstName: string;
     type: string;
     accessory: string;
+    birthDate: string;
   };
 };
 
 export default async function NaiveAnimalUpdatePage(props: Props) {
-  const animal = await updateAnimalById(
-    Number(props.params.animalId),
-    props.searchParams.firstName,
-    props.searchParams.type,
-    props.searchParams.accessory,
-  );
+  const animal = await updateAnimalById({
+    id: Number(props.params.animalId),
+    firstName: props.searchParams.firstName,
+    type: props.searchParams.type,
+    accessory: props.searchParams.accessory || null,
+    birthDate: new Date(props.searchParams.birthDate),
+  });
 
   if (!animal) {
     notFound();


### PR DESCRIPTION
Follow up PR to 
- #9 

Update the `animal-management-naive-dont-copy` pages to display birth dates.

- Creating a new animal
<img width="1500" alt="Screenshot 2024-01-10 at 15 45 57" src="https://github.com/upleveled/next-js-example-fall-2023-atvie/assets/80746311/236f39a4-79fb-40e1-8dd7-465197c4c0a5">

- Displaying a single existing animal:
<img width="1502" alt="Screenshot 2024-01-11 at 12 09 57" src="https://github.com/upleveled/next-js-example-fall-2023-atvie/assets/80746311/5570cb14-18f4-4af8-92ee-3cc4a96de0e1">

