### PR TITLE
Fix typo in SCSS module import statement

### DIFF
--- a/app/GenerateButton.tsx
+++ b/app/GenerateButton.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import style from './GenerateButton.module.scss';
+import styles from './GenerateButton.module.scss';
 
 export default function GenerateButton() {
   // You can also initialize it with a string, instead
@@ -32,7 +32,7 @@ export default function GenerateButton() {
   return (
     <div>
       <button
-        className={style.generateButton}
+        className={styles.generateButton}
         style={{ backgroundColor: color }}
         onClick={() => {
           const newColor = `#${Math.floor(Math.random() * 16777215).toString(


### PR DESCRIPTION
Fix a typo in the import statement by replacing `import style from ...` with the correct `import styles from ...`.
