### PR TITLE
Add missing html elements

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,6 +35,7 @@ export default async function RootLayout(props: Props) {
     <html lang="en">
       <body className={inter.className}>
         <CookieBanner />
+
         <header>
           <nav>
             <div>
@@ -67,7 +68,8 @@ export default async function RootLayout(props: Props) {
             </div>
           </nav>
         </header>
-        <main> {props.children}</main>
+
+        <main>{props.children}</main>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,36 +35,39 @@ export default async function RootLayout(props: Props) {
     <html lang="en">
       <body className={inter.className}>
         <CookieBanner />
-        <nav>
-          <div>
-            {/* This is not optimized */}
-            {/* <a href="/">Home</a> */}
-            {/* This is optimized */}
-            <Link href="/">Home</Link>
-            <Link href="/about">About</Link>
-            <Link href="/animals">Animals</Link>
-            <Link href="/fruits">Fruits</Link>
-            <Link href="/animals/dashboard">Dashboard</Link>
-            <Link href="/notes">Check Notes</Link>
-          </div>
+        <header>
+          <nav>
+            <div>
+              {/* This is not optimized */}
+              {/* <a href="/">Home</a> */}
+              {/* This is optimized */}
+              <Link href="/">Home</Link>
+              <Link href="/about">About</Link>
+              <Link href="/animals">Animals</Link>
+              <Link href="/fruits">Fruits</Link>
+              <Link href="/animals/dashboard">Dashboard</Link>
+              <Link href="/notes">Check Notes</Link>
+            </div>
 
-          {Math.floor(Math.random() * 10)}
-          <div>
-            {user ? (
-              <>
-                <div>{user.username}</div>
-                <LogoutButton />
-              </>
-            ) : (
-              <>
-                <Link href="/register">Register</Link>
-                <Link href="/login">Login</Link>
-              </>
-            )}
-          </div>
-        </nav>
-
-        {props.children}
+            {Math.floor(Math.random() * 10)}
+            <div>
+              {user ? (
+                <>
+                  <Link href={`/profile/${user.username}`}>
+                    {user.username}
+                  </Link>
+                  <LogoutButton />
+                </>
+              ) : (
+                <>
+                  <Link href="/register">Register</Link>
+                  <Link href="/login">Login</Link>
+                </>
+              )}
+            </div>
+          </nav>
+        </header>
+        <main> {props.children}</main>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import LocalStorage from './LocalStorage';
 
 export default function HomePage() {
   return (
-    <main>
+    <div>
       <GenerateButton />
       <LocalStorage />
       <h1>Hello UpLeveled!</h1>
@@ -20,6 +20,6 @@ export default function HomePage() {
         height={300}
       />
       <Image src={smilingCat} alt="Smiling cat" />
-    </main>
+    </div>
   );
 }


### PR DESCRIPTION
This PR adds the missing `header` and `main` HTMl tags to the next.js example as it was missing from previous examples

