### PR TITLE
Fix PostgreSQL v16 Fly.io lock file creation error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN pnpm build
 FROM node:lts-alpine AS runner
 ENV NODE_ENV production
 # Install necessary tools
-RUN apk add bash postgresql15
+RUN apk add bash postgresql
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 

--- a/scripts/fly-io-start.sh
+++ b/scripts/fly-io-start.sh
@@ -26,7 +26,7 @@ else
   su postgres -c "initdb -D $VOLUME_PATH/run/postgresql/data/"
 
   # Update PostgreSQL config path to use volume location if app has a volume
-  sed -i "s/'\/run\/postgresql'/'\/postgres-volume\/run\/postgresql'/g" /postgres-volume/run/postgresql/data/postgresql.conf || echo "PostgreSQL volume not mounted, running database as non-persistent (new deploys erase changes not saved in migrations)"
+  sed -i "s/#unix_socket_directories = '\/run\/postgresql'/unix_socket_directories = '\/postgres-volume\/run\/postgresql'/g" /postgres-volume/run/postgresql/data/postgresql.conf || echo "PostgreSQL volume not mounted, running database as non-persistent (new deploys erase changes not saved in migrations)"
 
   # Configure PostgreSQL to listen for connections from any address
   echo "listen_addresses='*'" >> $VOLUME_PATH/run/postgresql/data/postgresql.conf


### PR DESCRIPTION
Closes https://github.com/upleveled/next-js-example-fall-2023-atvie/issues/17

## Description

During the update for Fly.io to PostgreSQL v16, an issue occurred where the `unix_socket_directories` setting was commented out by the PostgreSQL upgrade process. This caused the deployment to fail as the lock file could not be created.
```
2023-12-18T16:29:12.740 app[3d8d9297b96748] otp [info] 2023-12-18 16:29:12.739 UTC [330] FATAL: could not create lock file "/run/postgresql/.s.PGSQL.5432.lock": No such file or directory
```

The issue has been resolved by uncommenting the `unix_socket_directories` setting using `sed`. This ensures that PostgreSQL correctly identifies the location of the socket files for connecting to the database.

