### PR TITLE
Fix Navigation title grammar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -47,7 +47,7 @@ export default async function RootLayout(props: Props) {
               <Link href="/animals">Animals</Link>
               <Link href="/fruits">Fruits</Link>
               <Link href="/animals/dashboard">Dashboard</Link>
-              <Link href="/notes">Check Notes</Link>
+              <Link href="/notes">Notes</Link>
             </div>
 
             {Math.floor(Math.random() * 10)}


### PR DESCRIPTION
This PR Changes the `Check Notes` to `Notes` in the navigation title in the example. This change is in relation to this comment https://github.com/upleveled/graphql-example-fall-2023-atvie/pull/13#discussion_r1467801379

Testing plan
- [x] CI passes