### PR TITLE
Make dashboard database queries secure

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
-import { getValidSessionByToken } from '../../../database/sessions';
+import { getValidSession } from '../../../database/sessions';
 import { getSafeReturnToPath } from '../../../util/validation';
 import LoginForm from './LoginForm';
 
@@ -18,8 +18,7 @@ export default async function LoginPage({ searchParams }: Props) {
 
   // 2. Check if the sessionToken cookie is still valid
   const session =
-    sessionTokenCookie &&
-    (await getValidSessionByToken(sessionTokenCookie.value));
+    sessionTokenCookie && (await getValidSession(sessionTokenCookie.value));
 
   // 3. If the sessionToken cookie is valid, redirect to home
   if (session) redirect(getSafeReturnToPath(searchParams.returnTo) || '/');

--- a/app/(auth)/logout/actions.ts
+++ b/app/(auth)/logout/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { cookies } from 'next/headers';
-import { deleteSessionByToken } from '../../../database/sessions';
+import { deleteSession } from '../../../database/sessions';
 
 export async function logout() {
   // Get the session token from the cookie
@@ -10,7 +10,7 @@ export async function logout() {
   const token = cookieStore.get('sessionToken');
 
   //  Delete the session from the database based on the token
-  if (token) await deleteSessionByToken(token.value);
+  if (token) await deleteSession(token.value);
 
   // Delete the session cookie from the browser
   cookieStore.set('sessionToken', '', {

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
-import { getValidSessionByToken } from '../../../database/sessions';
+import { getValidSession } from '../../../database/sessions';
 import { getSafeReturnToPath } from '../../../util/validation';
 import RegisterForm from './RegisterForm';
 
@@ -18,8 +18,7 @@ export default async function RegisterPage({ searchParams }: Props) {
 
   // 2. Check if the sessionToken cookie is still valid
   const session =
-    sessionTokenCookie &&
-    (await getValidSessionByToken(sessionTokenCookie.value));
+    sessionTokenCookie && (await getValidSession(sessionTokenCookie.value));
 
   // 3. If the sessionToken cookie is valid, redirect to home
   if (session) redirect(getSafeReturnToPath(searchParams.returnTo) || '/');

--- a/app/animal-management-naive-dont-copy/create/page.tsx
+++ b/app/animal-management-naive-dont-copy/create/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { createAnimalNaiveDontCopy } from '../../../database/animals';
+import { createAnimalInsecure } from '../../../database/animals';
 import { formatDate } from '../../../util/dates';
 
 export const metadata = {
@@ -16,7 +16,7 @@ type Props = {
 };
 
 export default async function NaiveCreateAnimalPage(props: Props) {
-  const animal = await createAnimalNaiveDontCopy({
+  const animal = await createAnimalInsecure({
     firstName: props.searchParams.firstName,
     type: props.searchParams.type,
     accessory: props.searchParams.accessory || null,

--- a/app/animal-management-naive-dont-copy/create/page.tsx
+++ b/app/animal-management-naive-dont-copy/create/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { createAnimal } from '../../../database/animals';
+import { createAnimalNaiveDontCopy } from '../../../database/animals';
 import { formatDate } from '../../../util/dates';
 
 export const metadata = {
@@ -16,7 +16,7 @@ type Props = {
 };
 
 export default async function NaiveCreateAnimalPage(props: Props) {
-  const animal = await createAnimal({
+  const animal = await createAnimalNaiveDontCopy({
     firstName: props.searchParams.firstName,
     type: props.searchParams.type,
     accessory: props.searchParams.accessory || null,

--- a/app/animal-management-naive-dont-copy/delete/[animalId]/page.tsx
+++ b/app/animal-management-naive-dont-copy/delete/[animalId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { deleteAnimalByIdNaiveDontCopy } from '../../../../database/animals';
+import { deleteAnimalByIdInsecure } from '../../../../database/animals';
 
 export const metadata = {
   title: 'Naive delete animal page',
@@ -12,9 +12,7 @@ type Props = {
 };
 
 export default async function DeleteAnimalPage(props: Props) {
-  const animal = await deleteAnimalByIdNaiveDontCopy(
-    Number(props.params.animalId),
-  );
+  const animal = await deleteAnimalByIdInsecure(Number(props.params.animalId));
 
   if (!animal) {
     notFound();

--- a/app/animal-management-naive-dont-copy/delete/[animalId]/page.tsx
+++ b/app/animal-management-naive-dont-copy/delete/[animalId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { deleteAnimalById } from '../../../../database/animals';
+import { deleteAnimalByIdNaiveDontCopy } from '../../../../database/animals';
 
 export const metadata = {
   title: 'Naive delete animal page',
@@ -12,7 +12,9 @@ type Props = {
 };
 
 export default async function DeleteAnimalPage(props: Props) {
-  const animal = await deleteAnimalById(Number(props.params.animalId));
+  const animal = await deleteAnimalByIdNaiveDontCopy(
+    Number(props.params.animalId),
+  );
 
   if (!animal) {
     notFound();

--- a/app/animal-management-naive-dont-copy/delete/[animalId]/page.tsx
+++ b/app/animal-management-naive-dont-copy/delete/[animalId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { deleteAnimalByIdInsecure } from '../../../../database/animals';
+import { deleteAnimalInsecure } from '../../../../database/animals';
 
 export const metadata = {
   title: 'Naive delete animal page',
@@ -12,7 +12,7 @@ type Props = {
 };
 
 export default async function DeleteAnimalPage(props: Props) {
-  const animal = await deleteAnimalByIdInsecure(Number(props.params.animalId));
+  const animal = await deleteAnimalInsecure(Number(props.params.animalId));
 
   if (!animal) {
     notFound();

--- a/app/animal-management-naive-dont-copy/layout.tsx
+++ b/app/animal-management-naive-dont-copy/layout.tsx
@@ -1,6 +1,6 @@
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
-import { getValidSessionByToken } from '../../database/sessions';
+import { getValidSession } from '../../database/sessions';
 
 type Props = {
   children: React.ReactNode;
@@ -14,8 +14,7 @@ export default async function AnimalsNaiveLayout(props: Props) {
 
   // 2. check if the sessionToken has a valid session
   const session =
-    sessionTokenCookie &&
-    (await getValidSessionByToken(sessionTokenCookie.value));
+    sessionTokenCookie && (await getValidSession(sessionTokenCookie.value));
 
   console.log('Check Xpath: ', headersList.get('x-pathname'));
 

--- a/app/animal-management-naive-dont-copy/read/[animalId]/page.tsx
+++ b/app/animal-management-naive-dont-copy/read/[animalId]/page.tsx
@@ -1,10 +1,12 @@
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
-import { getAnimalById } from '../../../../database/animals';
+import { getAnimalByIdInsecure } from '../../../../database/animals';
 import { formatDate } from '../../../../util/dates';
 
 export async function generateMetadata(props: Props) {
-  const singleAnimal = await getAnimalById(Number(props.params.animalId));
+  const singleAnimal = await getAnimalByIdInsecure(
+    Number(props.params.animalId),
+  );
 
   return {
     title: singleAnimal ? singleAnimal.firstName : '',
@@ -18,7 +20,9 @@ type Props = {
 };
 
 export default async function NaiveAnimalPage(props: Props) {
-  const singleAnimal = await getAnimalById(Number(props.params.animalId));
+  const singleAnimal = await getAnimalByIdInsecure(
+    Number(props.params.animalId),
+  );
 
   if (!singleAnimal) {
     return notFound();

--- a/app/animal-management-naive-dont-copy/read/[animalId]/page.tsx
+++ b/app/animal-management-naive-dont-copy/read/[animalId]/page.tsx
@@ -1,12 +1,10 @@
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
-import { getAnimalByIdInsecure } from '../../../../database/animals';
+import { getAnimalInsecure } from '../../../../database/animals';
 import { formatDate } from '../../../../util/dates';
 
 export async function generateMetadata(props: Props) {
-  const singleAnimal = await getAnimalByIdInsecure(
-    Number(props.params.animalId),
-  );
+  const singleAnimal = await getAnimalInsecure(Number(props.params.animalId));
 
   return {
     title: singleAnimal ? singleAnimal.firstName : '',
@@ -20,9 +18,7 @@ type Props = {
 };
 
 export default async function NaiveAnimalPage(props: Props) {
-  const singleAnimal = await getAnimalByIdInsecure(
-    Number(props.params.animalId),
-  );
+  const singleAnimal = await getAnimalInsecure(Number(props.params.animalId));
 
   if (!singleAnimal) {
     return notFound();

--- a/app/animal-management-naive-dont-copy/read/page.tsx
+++ b/app/animal-management-naive-dont-copy/read/page.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { getAnimals } from '../../../database/animals';
+import { getAnimalsInsecure } from '../../../database/animals';
 
 export const metadata = {
   title: 'Naive Animals page',
@@ -8,7 +8,7 @@ export const metadata = {
 };
 
 export default async function NaiveAnimalsPage() {
-  const animals = await getAnimals();
+  const animals = await getAnimalsInsecure();
 
   return (
     <div>

--- a/app/animal-management-naive-dont-copy/update/[animalId]/page.tsx
+++ b/app/animal-management-naive-dont-copy/update/[animalId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { updateAnimalById } from '../../../../database/animals';
+import { updateAnimalByIdNaiveDontCopy } from '../../../../database/animals';
 
 type Props = {
   params: {
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export default async function NaiveAnimalUpdatePage(props: Props) {
-  const animal = await updateAnimalById({
+  const animal = await updateAnimalByIdNaiveDontCopy({
     id: Number(props.params.animalId),
     firstName: props.searchParams.firstName,
     type: props.searchParams.type,

--- a/app/animal-management-naive-dont-copy/update/[animalId]/page.tsx
+++ b/app/animal-management-naive-dont-copy/update/[animalId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { updateAnimalByIdInsecure } from '../../../../database/animals';
+import { updateAnimalInsecure } from '../../../../database/animals';
 
 type Props = {
   params: {
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export default async function NaiveAnimalUpdatePage(props: Props) {
-  const animal = await updateAnimalByIdInsecure({
+  const animal = await updateAnimalInsecure({
     id: Number(props.params.animalId),
     firstName: props.searchParams.firstName,
     type: props.searchParams.type,

--- a/app/animal-management-naive-dont-copy/update/[animalId]/page.tsx
+++ b/app/animal-management-naive-dont-copy/update/[animalId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { updateAnimalByIdNaiveDontCopy } from '../../../../database/animals';
+import { updateAnimalByIdInsecure } from '../../../../database/animals';
 
 type Props = {
   params: {
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export default async function NaiveAnimalUpdatePage(props: Props) {
-  const animal = await updateAnimalByIdNaiveDontCopy({
+  const animal = await updateAnimalByIdInsecure({
     id: Number(props.params.animalId),
     firstName: props.searchParams.firstName,
     type: props.searchParams.type,

--- a/app/animals/[animalId]/page.tsx
+++ b/app/animals/[animalId]/page.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
-import { getAnimalById } from '../../../database/animals';
+import { getAnimalByIdInsecure } from '../../../database/animals';
 import { formatDate, getDaysUntilNextBirthday } from '../../../util/dates';
 
 type Props = {
@@ -10,7 +10,9 @@ type Props = {
 };
 
 export async function generateMetadata(props: Props) {
-  const singleAnimal = await getAnimalById(Number(props.params.animalId));
+  const singleAnimal = await getAnimalByIdInsecure(
+    Number(props.params.animalId),
+  );
 
   return {
     title: singleAnimal ? singleAnimal.firstName : '',
@@ -18,7 +20,9 @@ export async function generateMetadata(props: Props) {
 }
 
 export default async function AnimalPage(props: Props) {
-  const singleAnimal = await getAnimalById(Number(props.params.animalId));
+  const singleAnimal = await getAnimalByIdInsecure(
+    Number(props.params.animalId),
+  );
 
   if (!singleAnimal) {
     return notFound();

--- a/app/animals/[animalId]/page.tsx
+++ b/app/animals/[animalId]/page.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
-import { getAnimalByIdInsecure } from '../../../database/animals';
+import { getAnimalInsecure } from '../../../database/animals';
 import { formatDate, getDaysUntilNextBirthday } from '../../../util/dates';
 
 type Props = {
@@ -10,9 +10,7 @@ type Props = {
 };
 
 export async function generateMetadata(props: Props) {
-  const singleAnimal = await getAnimalByIdInsecure(
-    Number(props.params.animalId),
-  );
+  const singleAnimal = await getAnimalInsecure(Number(props.params.animalId));
 
   return {
     title: singleAnimal ? singleAnimal.firstName : '',
@@ -20,9 +18,7 @@ export async function generateMetadata(props: Props) {
 }
 
 export default async function AnimalPage(props: Props) {
-  const singleAnimal = await getAnimalByIdInsecure(
-    Number(props.params.animalId),
-  );
+  const singleAnimal = await getAnimalInsecure(Number(props.params.animalId));
 
   if (!singleAnimal) {
     return notFound();

--- a/app/animals/dashboard/page.tsx
+++ b/app/animals/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { getAnimals } from '../../../database/animals';
-import { getValidSessionByToken } from '../../../database/sessions';
+import { getValidSession } from '../../../database/sessions';
 import AnimalsForm from './AnimalsForm';
 
 export const metadata = {
@@ -17,8 +17,7 @@ export default async function Dashboard() {
 
   // 2. Check if the sessionToken cookie is still valid
   const session =
-    sessionTokenCookie &&
-    (await getValidSessionByToken(sessionTokenCookie.value));
+    sessionTokenCookie && (await getValidSession(sessionTokenCookie.value));
 
   //  Query your database to check if this user has the right access to this page
 

--- a/app/animals/dashboard/page.tsx
+++ b/app/animals/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
-import { getAnimals } from '../../../database/animals';
+import { getAnimalsBySessionToken } from '../../../database/animals';
 import { getValidSessionByToken } from '../../../database/sessions';
 import AnimalsForm from './AnimalsForm';
 
@@ -26,7 +26,7 @@ export default async function Dashboard() {
   if (!session) redirect('/login?returnTo=/animals/dashboard');
 
   // 4. If the sessionToken cookie is valid, allow access to dashboard page
-  const animals = await getAnimals();
+  const animals = await getAnimalsBySessionToken(session.token);
 
   return <AnimalsForm animals={animals} />;
 }

--- a/app/animals/dashboard/page.tsx
+++ b/app/animals/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
-import { getAnimalsBySessionToken } from '../../../database/animals';
+import { getAnimals } from '../../../database/animals';
 import { getValidSessionByToken } from '../../../database/sessions';
 import AnimalsForm from './AnimalsForm';
 
@@ -26,7 +26,7 @@ export default async function Dashboard() {
   if (!session) redirect('/login?returnTo=/animals/dashboard');
 
   // 4. If the sessionToken cookie is valid, allow access to dashboard page
-  const animals = await getAnimalsBySessionToken(session.token);
+  const animals = await getAnimals(session.token);
 
   return <AnimalsForm animals={animals} />;
 }

--- a/app/animals/page.tsx
+++ b/app/animals/page.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { getAnimals } from '../../database/animals';
+import { getAnimalsInsecure } from '../../database/animals';
 
 export const metadata = {
   title: 'Animals page',
@@ -8,7 +8,7 @@ export const metadata = {
 };
 
 export default async function AnimalsPage() {
-  const animals = await getAnimals();
+  const animals = await getAnimalsInsecure();
 
   return (
     <div>

--- a/app/animals/paginated/page.tsx
+++ b/app/animals/paginated/page.tsx
@@ -1,8 +1,8 @@
-import { getAnimalsWithLimitAndOffset } from '../../../database/animals';
+import { getAnimalsWithLimitAndOffsetInsecure } from '../../../database/animals';
 import Dashboard from './Dashboard';
 
 export default async function AnimalsPaginatedPage() {
-  const animals = await getAnimalsWithLimitAndOffset(2, 0);
+  const animals = await getAnimalsWithLimitAndOffsetInsecure(2, 0);
 
   return <Dashboard animals={animals} />;
 }

--- a/app/animals/with-foods/[animalId]/page.js
+++ b/app/animals/with-foods/[animalId]/page.js
@@ -2,7 +2,7 @@ import { Image } from 'next/dist/client/image-component';
 import { notFound } from 'next/navigation';
 import {
   getAnimalsWithFoodsInsecure,
-  getAnimalWithFoodsByIdInsecure,
+  getAnimalWithFoodsInsecure,
 } from '../../../../database/animals';
 import { reduceAnimalsWithFoods } from '../../../../util/dataStructures';
 
@@ -10,7 +10,7 @@ export default async function AnimalFoodPage(props) {
   const animalsWithFoods = await getAnimalsWithFoodsInsecure(
     props.params.animalId,
   );
-  const animalWithFoodJsonAgg = await getAnimalWithFoodsByIdInsecure(
+  const animalWithFoodJsonAgg = await getAnimalWithFoodsInsecure(
     props.params.animalId,
   );
 

--- a/app/animals/with-foods/[animalId]/page.js
+++ b/app/animals/with-foods/[animalId]/page.js
@@ -1,14 +1,16 @@
 import { Image } from 'next/dist/client/image-component';
 import { notFound } from 'next/navigation';
 import {
-  getAnimalsWithFoods,
-  getAnimalWithFoodsById,
+  getAnimalsWithFoodsInsecure,
+  getAnimalWithFoodsByIdInsecure,
 } from '../../../../database/animals';
 import { reduceAnimalsWithFoods } from '../../../../util/dataStructures';
 
 export default async function AnimalFoodPage(props) {
-  const animalsWithFoods = await getAnimalsWithFoods(props.params.animalId);
-  const animalWithFoodJsonAgg = await getAnimalWithFoodsById(
+  const animalsWithFoods = await getAnimalsWithFoodsInsecure(
+    props.params.animalId,
+  );
+  const animalWithFoodJsonAgg = await getAnimalWithFoodsByIdInsecure(
     props.params.animalId,
   );
 

--- a/app/api/(auth)/login/route.ts
+++ b/app/api/(auth)/login/route.ts
@@ -3,8 +3,8 @@ import bcrypt from 'bcrypt';
 import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { createSession } from '../../../../database/sessions';
-import { getUserWithPasswordHashByUsername } from '../../../../database/users';
+import { createSessionInsecure } from '../../../../database/sessions';
+import { getUserWithPasswordHashByUsernameInsecure } from '../../../../database/users';
 import { secureCookieOptions } from '../../../../util/cookies';
 
 const loginSchema = z.object({
@@ -43,7 +43,7 @@ export async function POST(
   }
 
   // 3. verify the user credentials
-  const userWithPasswordHash = await getUserWithPasswordHashByUsername(
+  const userWithPasswordHash = await getUserWithPasswordHashByUsernameInsecure(
     result.data.username,
   );
 
@@ -76,7 +76,7 @@ export async function POST(
   const token = crypto.randomBytes(100).toString('base64');
 
   // 5. Create the session record
-  const session = await createSession(userWithPasswordHash.id, token);
+  const session = await createSessionInsecure(userWithPasswordHash.id, token);
 
   if (!session) {
     return NextResponse.json(

--- a/app/api/(auth)/register/route.ts
+++ b/app/api/(auth)/register/route.ts
@@ -3,8 +3,11 @@ import bcrypt from 'bcrypt';
 import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { createSession } from '../../../../database/sessions';
-import { createUser, getUserByUsername } from '../../../../database/users';
+import { createSessionInsecure } from '../../../../database/sessions';
+import {
+  createUserInsecure,
+  getUserByUsernameInsecure,
+} from '../../../../database/users';
 import { User } from '../../../../migrations/00006-createTableUsers';
 import { secureCookieOptions } from '../../../../util/cookies';
 
@@ -42,7 +45,7 @@ export async function POST(
   }
 
   // 3. Check if user already exist in the database
-  const user = await getUserByUsername(result.data.username);
+  const user = await getUserByUsernameInsecure(result.data.username);
 
   if (user) {
     return NextResponse.json(
@@ -57,7 +60,7 @@ export async function POST(
   const passwordHash = await bcrypt.hash(result.data.password, 12);
 
   // 5. Save the user information with the hashed password in the database
-  const newUser = await createUser(result.data.username, passwordHash);
+  const newUser = await createUserInsecure(result.data.username, passwordHash);
 
   if (!newUser) {
     return NextResponse.json(
@@ -77,7 +80,7 @@ export async function POST(
   const token = crypto.randomBytes(100).toString('base64');
 
   // 5. Create the session record
-  const session = await createSession(newUser.id, token);
+  const session = await createSessionInsecure(newUser.id, token);
 
   if (!session) {
     return NextResponse.json(

--- a/app/api/animals/[animalId]/route.ts
+++ b/app/api/animals/[animalId]/route.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import {
   deleteAnimalBySessionToken,
   getAnimalById,
-  updateAnimalById,
+  updateAnimalBySessionToken,
 } from '../../../../database/animals';
 import { Animal } from '../../../../migrations/00000-createTableAnimal';
 import { Error } from '../route';
@@ -85,14 +85,18 @@ export async function PUT(
     );
   }
 
+  const sessionTokenCookie = cookies().get('sessionToken');
+
   // query the database to update the animal
-  const animal = await updateAnimalById({
-    id: animalId,
-    firstName: result.data.firstName,
-    type: result.data.type,
-    accessory: result.data.accessory || null,
-    birthDate: result.data.birthDate,
-  });
+  const animal =
+    sessionTokenCookie &&
+    (await updateAnimalBySessionToken(sessionTokenCookie.value, {
+      id: animalId,
+      firstName: result.data.firstName,
+      type: result.data.type,
+      accessory: result.data.accessory || null,
+      birthDate: result.data.birthDate,
+    }));
 
   if (!animal) {
     return NextResponse.json(

--- a/app/api/animals/[animalId]/route.ts
+++ b/app/api/animals/[animalId]/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
   deleteAnimalBySessionToken,
-  getAnimalById,
+  getAnimalByIdInsecure,
   updateAnimalBySessionToken,
 } from '../../../../database/animals';
 import { Animal } from '../../../../migrations/00000-createTableAnimal';
@@ -40,7 +40,7 @@ export async function GET(
     );
   }
 
-  const animal = await getAnimalById(animalId);
+  const animal = await getAnimalByIdInsecure(animalId);
 
   if (!animal) {
     return NextResponse.json(

--- a/app/api/animals/[animalId]/route.ts
+++ b/app/api/animals/[animalId]/route.ts
@@ -126,6 +126,7 @@ export async function DELETE(
       { status: 400 },
     );
   }
+
   const sessionTokenCookie = cookies().get('sessionToken');
 
   const animal =

--- a/app/api/animals/[animalId]/route.ts
+++ b/app/api/animals/[animalId]/route.ts
@@ -2,9 +2,9 @@ import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
-  deleteAnimalBySessionToken,
+  deleteAnimal,
   getAnimalByIdInsecure,
-  updateAnimalBySessionToken,
+  updateAnimal,
 } from '../../../../database/animals';
 import { Animal } from '../../../../migrations/00000-createTableAnimal';
 import { Error } from '../route';
@@ -90,7 +90,7 @@ export async function PUT(
   // query the database to update the animal
   const animal =
     sessionTokenCookie &&
-    (await updateAnimalBySessionToken(sessionTokenCookie.value, {
+    (await updateAnimal(sessionTokenCookie.value, {
       id: animalId,
       firstName: result.data.firstName,
       type: result.data.type,
@@ -130,7 +130,7 @@ export async function DELETE(
 
   const animal =
     sessionTokenCookie &&
-    (await deleteAnimalBySessionToken(sessionTokenCookie.value, animalId));
+    (await deleteAnimal(sessionTokenCookie.value, animalId));
 
   if (!animal) {
     return NextResponse.json(

--- a/app/api/animals/[animalId]/route.ts
+++ b/app/api/animals/[animalId]/route.ts
@@ -1,7 +1,8 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
-  deleteAnimalById,
+  deleteAnimalBySessionToken,
   getAnimalById,
   updateAnimalById,
 } from '../../../../database/animals';
@@ -121,8 +122,11 @@ export async function DELETE(
       { status: 400 },
     );
   }
+  const sessionTokenCookie = cookies().get('sessionToken');
 
-  const animal = await deleteAnimalById(animalId);
+  const animal =
+    sessionTokenCookie &&
+    (await deleteAnimalBySessionToken(sessionTokenCookie.value, animalId));
 
   if (!animal) {
     return NextResponse.json(

--- a/app/api/animals/[animalId]/route.ts
+++ b/app/api/animals/[animalId]/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
   deleteAnimal,
-  getAnimalByIdInsecure,
+  getAnimalInsecure,
   updateAnimal,
 } from '../../../../database/animals';
 import { Animal } from '../../../../migrations/00000-createTableAnimal';
@@ -40,7 +40,7 @@ export async function GET(
     );
   }
 
-  const animal = await getAnimalByIdInsecure(animalId);
+  const animal = await getAnimalInsecure(animalId);
 
   if (!animal) {
     return NextResponse.json(

--- a/app/api/animals/route.ts
+++ b/app/api/animals/route.ts
@@ -1,7 +1,8 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
-  createAnimal,
+  createAnimalBySessionToken,
   getAnimalsWithLimitAndOffset,
 } from '../../../database/animals';
 import { Animal } from '../../../migrations/00000-createTableAnimal';
@@ -76,13 +77,17 @@ export async function POST(
     );
   }
 
+  const sessionTokenCookie = cookies().get('sessionToken');
+
   // Get the animals from the database
-  const animal = await createAnimal({
-    firstName: result.data.firstName,
-    type: result.data.type,
-    accessory: result.data.accessory || null,
-    birthDate: result.data.birthDate,
-  });
+  const animal =
+    sessionTokenCookie &&
+    (await createAnimalBySessionToken(sessionTokenCookie.value, {
+      firstName: result.data.firstName,
+      type: result.data.type,
+      accessory: result.data.accessory || null,
+      birthDate: result.data.birthDate,
+    }));
 
   if (!animal) {
     return NextResponse.json(

--- a/app/api/animals/route.ts
+++ b/app/api/animals/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
   createAnimalBySessionToken,
-  getAnimalsWithLimitAndOffset,
+  getAnimalsWithLimitAndOffsetInsecure,
 } from '../../../database/animals';
 import { Animal } from '../../../migrations/00000-createTableAnimal';
 
@@ -52,7 +52,7 @@ export async function GET(
   }
 
   // query the database to get all the animals only if a valid session token is passed
-  const animals = await getAnimalsWithLimitAndOffset(limit, offset);
+  const animals = await getAnimalsWithLimitAndOffsetInsecure(limit, offset);
 
   return NextResponse.json({
     animals: animals,

--- a/app/api/animals/route.ts
+++ b/app/api/animals/route.ts
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
-  createAnimalBySessionToken,
+  createAnimal,
   getAnimalsWithLimitAndOffsetInsecure,
 } from '../../../database/animals';
 import { Animal } from '../../../migrations/00000-createTableAnimal';
@@ -82,7 +82,7 @@ export async function POST(
   // Get the animals from the database
   const animal =
     sessionTokenCookie &&
-    (await createAnimalBySessionToken(sessionTokenCookie.value, {
+    (await createAnimal(sessionTokenCookie.value, {
       firstName: result.data.firstName,
       type: result.data.type,
       accessory: result.data.accessory || null,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import { Inter } from 'next/font/google';
 import { cookies } from 'next/headers';
 import Link from 'next/link';
 import { ReactNode } from 'react';
-import { getUserBySessionToken } from '../database/users';
+import { getUser } from '../database/users';
 import LogoutButton from './(auth)/logout/LogoutButton';
 import CookieBanner from './CookieBanner';
 
@@ -28,8 +28,7 @@ export default async function RootLayout(props: Props) {
   const cookieStore = cookies();
   const sessionToken = cookieStore.get('sessionToken');
 
-  const user =
-    sessionToken && (await getUserBySessionToken(sessionToken.value));
+  const user = sessionToken && (await getUser(sessionToken.value));
 
   return (
     <html lang="en">

--- a/app/notes/[noteId]/page.tsx
+++ b/app/notes/[noteId]/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import Link from 'next/link';
-import { getNoteBySessionToken } from '../../../database/notes';
+import { getNote } from '../../../database/notes';
 import styles from './page.module.scss';
 
 type Props = {
@@ -18,10 +18,7 @@ export default async function NotePage({ params }: Props) {
   // 2. Query the notes with the session token and noteId
   const note =
     sessionTokenCookie &&
-    (await getNoteBySessionToken(
-      sessionTokenCookie.value,
-      Number(params.noteId),
-    ));
+    (await getNote(sessionTokenCookie.value, Number(params.noteId)));
 
   // 3. If there is no note for the current user, show restricted access message
   if (!note) {

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
-import { getNotesBySessionToken } from '../../database/notes';
-import { getUserBySessionToken } from '../../database/users';
+import { getNotes } from '../../database/notes';
+import { getUser } from '../../database/users';
 import NotesForm from './NotesForm';
 
 export default async function NotesPage() {
@@ -15,14 +15,12 @@ export default async function NotesPage() {
   // 5. Checking if the sessionToken cookie exists
   const sessionTokenCookie = cookies().get('sessionToken');
 
-  const user =
-    sessionTokenCookie &&
-    (await getUserBySessionToken(sessionTokenCookie.value));
+  const user = sessionTokenCookie && (await getUser(sessionTokenCookie.value));
 
   if (!user) redirect('/login?returnTo=/notes');
 
   // 6. Display the notes for the current logged in user
-  const notes = await getNotesBySessionToken(sessionTokenCookie.value);
+  const notes = await getNotes(sessionTokenCookie.value);
 
   return <NotesForm notes={notes} user={user} />;
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
-import { getUserBySessionToken } from '../../database/users';
+import { getUser } from '../../database/users';
 
 export default async function UserProfilePage() {
   // Task: Add redirect to login page if user is not logged in
@@ -8,9 +8,7 @@ export default async function UserProfilePage() {
   const sessionTokenCookie = cookies().get('sessionToken');
 
   // 2. Query the current user with the sessionToken
-  const user =
-    sessionTokenCookie &&
-    (await getUserBySessionToken(sessionTokenCookie.value));
+  const user = sessionTokenCookie && (await getUser(sessionTokenCookie.value));
 
   // 3. If user doesn't exist, redirect to login page
   if (!user) {

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -15,18 +15,13 @@ import {
 //   { id: 5, firstName: 'Bili', type: 'Capybara', accessory: 'Pen' },
 // ];
 
-export const getAnimalsInsecure = cache(async () => {
-  // return animals;
-  const animals = await sql<Animal[]>`
-    SELECT
-      *
-    FROM
-      animals
-  `;
-  return animals;
-});
+// export function getAnimal(id: number) {
+//   return animals1.find((animal) => animal.id === id);
+// }
 
-// Secured database query for getting animals by session token
+// Secure database queries starts here
+// All queries without `Insecure` are protected by session tokens
+
 export const getAnimals = cache(async (token: string) => {
   const animals = await sql<Animal[]>`
     SELECT
@@ -41,95 +36,6 @@ export const getAnimals = cache(async (token: string) => {
   return animals;
 });
 
-export const getAnimalsWithLimitAndOffsetInsecure = cache(
-  async (limit: number, offset: number) => {
-    // return animals;
-    const animals = await sql<Animal[]>`
-      SELECT
-        *
-      FROM
-        animals
-      LIMIT
-        ${limit}
-      OFFSET
-        ${offset}
-    `;
-    return animals;
-  },
-);
-
-export const getAnimalByIdInsecure = cache(async (id: number) => {
-  // Postgres always returns an array
-  const [animal] = await sql<Animal[]>`
-    SELECT
-      *
-    FROM
-      animals
-    WHERE
-      id = ${id}
-  `;
-  return animal;
-});
-
-// Insecure database query for deleting an animal by id
-export const deleteAnimalByIdInsecure = cache(async (id: number) => {
-  const [animal] = await sql<Animal[]>`
-    DELETE FROM animals
-    WHERE
-      id = ${id}
-    RETURNING
-      *
-  `;
-
-  return animal;
-});
-
-// Secure database query for deleting an animal by session token
-export const deleteAnimal = cache(async (token: string, id: number) => {
-  const [animal] = await sql<Animal[]>`
-    DELETE FROM animals USING sessions
-    WHERE
-      sessions.token = ${token}
-      AND sessions.expiry_timestamp > now()
-      AND animals.id = ${id}
-    RETURNING
-      animals.*
-  `;
-
-  return animal;
-});
-
-// Insecure database query for creating an animal by id
-export const createAnimalInsecure = cache(
-  // Accept an object as an argument, allowing optional properties like
-  // `accessory` before required properties like `birthDate`
-  //
-  // `Omit` is a TS utility type that excludes a property from a type
-  async (newAnimal: Omit<Animal, 'id'>) => {
-    const [animal] = await sql<Animal[]>`
-      INSERT INTO
-        animals (
-          first_name,
-          type,
-          accessory,
-          birth_date
-        )
-      VALUES
-        (
-          ${newAnimal.firstName},
-          ${newAnimal.type},
-          ${newAnimal.accessory},
-          ${newAnimal.birthDate}
-        )
-      RETURNING
-        *
-    `;
-
-    return animal;
-  },
-);
-
-// Secure database query for creating an animal by session token
 export const createAnimal = cache(
   async (token: string, newAnimal: Omit<Animal, 'id'>) => {
     const [animal] = await sql<Animal[]>`
@@ -159,24 +65,6 @@ export const createAnimal = cache(
   },
 );
 
-// Insecure database query for updating an animal by id
-export const updateAnimalByIdInsecure = cache(async (updatedAnimal: Animal) => {
-  const [animal] = await sql<Animal[]>`
-    UPDATE animals
-    SET
-      first_name = ${updatedAnimal.firstName},
-      type = ${updatedAnimal.type},
-      accessory = ${updatedAnimal.accessory},
-      birth_date = ${updatedAnimal.birthDate}
-    WHERE
-      id = ${updatedAnimal.id}
-    RETURNING
-      *
-  `;
-  return animal;
-});
-
-// Secure database query for updating an animal by session token
 export const updateAnimal = cache(
   async (token: string, updatedAnimal: Animal) => {
     const [animal] = await sql<Animal[]>`
@@ -199,9 +87,46 @@ export const updateAnimal = cache(
   },
 );
 
-// export function getAnimal(id: number) {
-//   return animals1.find((animal) => animal.id === id);
-// }
+export const deleteAnimal = cache(async (token: string, id: number) => {
+  const [animal] = await sql<Animal[]>`
+    DELETE FROM animals USING sessions
+    WHERE
+      sessions.token = ${token}
+      AND sessions.expiry_timestamp > now()
+      AND animals.id = ${id}
+    RETURNING
+      animals.*
+  `;
+
+  return animal;
+});
+
+// Insecure database queries starts here
+// All queries with `Insecure` are not protected by session tokens
+
+export const getAnimalsInsecure = cache(async () => {
+  // return animals;
+  const animals = await sql<Animal[]>`
+    SELECT
+      *
+    FROM
+      animals
+  `;
+  return animals;
+});
+
+export const getAnimalByIdInsecure = cache(async (id: number) => {
+  // Postgres always returns an array
+  const [animal] = await sql<Animal[]>`
+    SELECT
+      *
+    FROM
+      animals
+    WHERE
+      id = ${id}
+  `;
+  return animal;
+});
 
 // animalId: number;
 // animalFirstName: string;
@@ -258,6 +183,80 @@ export const getAnimalWithFoodsByIdInsecure = cache(async (id: number) => {
       animals.type,
       animals.accessory,
       animals.id;
+  `;
+
+  return animal;
+});
+
+export const getAnimalsWithLimitAndOffsetInsecure = cache(
+  async (limit: number, offset: number) => {
+    // return animals;
+    const animals = await sql<Animal[]>`
+      SELECT
+        *
+      FROM
+        animals
+      LIMIT
+        ${limit}
+      OFFSET
+        ${offset}
+    `;
+    return animals;
+  },
+);
+
+export const createAnimalInsecure = cache(
+  // Accept an object as an argument, allowing optional properties like
+  // `accessory` before required properties like `birthDate`
+  //
+  // `Omit` is a TS utility type that excludes a property from a type
+  async (newAnimal: Omit<Animal, 'id'>) => {
+    const [animal] = await sql<Animal[]>`
+      INSERT INTO
+        animals (
+          first_name,
+          type,
+          accessory,
+          birth_date
+        )
+      VALUES
+        (
+          ${newAnimal.firstName},
+          ${newAnimal.type},
+          ${newAnimal.accessory},
+          ${newAnimal.birthDate}
+        )
+      RETURNING
+        *
+    `;
+
+    return animal;
+  },
+);
+
+export const updateAnimalByIdInsecure = cache(async (updatedAnimal: Animal) => {
+  const [animal] = await sql<Animal[]>`
+    UPDATE animals
+    SET
+      first_name = ${updatedAnimal.firstName},
+      type = ${updatedAnimal.type},
+      accessory = ${updatedAnimal.accessory},
+      birth_date = ${updatedAnimal.birthDate}
+    WHERE
+      id = ${updatedAnimal.id}
+    RETURNING
+      *
+  `;
+  return animal;
+});
+
+export const deleteAnimalByIdInsecure = cache(async (id: number) => {
+  const [animal] = await sql<Animal[]>`
+    DELETE FROM animals
+    WHERE
+      id = ${id}
+    RETURNING
+      *
   `;
 
   return animal;

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -165,6 +165,29 @@ export const updateAnimalByIdNaiveDontCopy = cache(
   },
 );
 
+// Secure database query for updating an animal by session token
+export const updateAnimalBySessionToken = cache(
+  async (token: string, updatedAnimal: Animal) => {
+    const [animal] = await sql<Animal[]>`
+      UPDATE animals
+      SET
+        first_name = ${updatedAnimal.firstName},
+        type = ${updatedAnimal.type},
+        accessory = ${updatedAnimal.accessory},
+        birth_date = ${updatedAnimal.birthDate}
+      FROM
+        sessions
+      WHERE
+        sessions.token = ${token}
+        AND sessions.expiry_timestamp > now()
+        AND animals.id = ${updatedAnimal.id}
+      RETURNING
+        animals.*
+    `;
+    return animal;
+  },
+);
+
 // export function getAnimal(id: number) {
 //   return animals1.find((animal) => animal.id === id);
 // }

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -26,6 +26,21 @@ export const getAnimals = cache(async () => {
   return animals;
 });
 
+// Secured database query for getting animals by session token
+export const getAnimalsBySessionToken = cache(async (token: string) => {
+  const animals = await sql<Animal[]>`
+    SELECT
+      animals.*
+    FROM
+      animals
+      INNER JOIN sessions ON (
+        sessions.token = ${token}
+        AND sessions.expiry_timestamp > now()
+      )
+  `;
+  return animals;
+});
+
 export const getAnimalsWithLimitAndOffset = cache(
   async (limit: number, offset: number) => {
     // return animals;

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -101,7 +101,7 @@ export const deleteAnimal = cache(async (token: string, id: number) => {
   return animal;
 });
 
-// Insecure database queries starts here
+// Insecure database queries start here
 // All queries marked `Insecure` do not use session tokens to authenticate the user
 
 export const getAnimalsInsecure = cache(async () => {

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -74,7 +74,6 @@ export const deleteAnimalBySessionToken = cache(
   async (token: string, id: number) => {
     const [animal] = await sql<Animal[]>`
       DELETE FROM animals USING sessions
-      INNER JOIN users ON sessions.user_id = users.id
       WHERE
         sessions.token = ${token}
         AND sessions.expiry_timestamp > now()

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -27,7 +27,7 @@ export const getAnimalsInsecure = cache(async () => {
 });
 
 // Secured database query for getting animals by session token
-export const getAnimalsBySessionToken = cache(async (token: string) => {
+export const getAnimals = cache(async (token: string) => {
   const animals = await sql<Animal[]>`
     SELECT
       animals.*
@@ -85,21 +85,19 @@ export const deleteAnimalByIdInsecure = cache(async (id: number) => {
 });
 
 // Secure database query for deleting an animal by session token
-export const deleteAnimalBySessionToken = cache(
-  async (token: string, id: number) => {
-    const [animal] = await sql<Animal[]>`
-      DELETE FROM animals USING sessions
-      WHERE
-        sessions.token = ${token}
-        AND sessions.expiry_timestamp > now()
-        AND animals.id = ${id}
-      RETURNING
-        animals.*
-    `;
+export const deleteAnimal = cache(async (token: string, id: number) => {
+  const [animal] = await sql<Animal[]>`
+    DELETE FROM animals USING sessions
+    WHERE
+      sessions.token = ${token}
+      AND sessions.expiry_timestamp > now()
+      AND animals.id = ${id}
+    RETURNING
+      animals.*
+  `;
 
-    return animal;
-  },
-);
+  return animal;
+});
 
 // Insecure database query for creating an animal by id
 export const createAnimalInsecure = cache(
@@ -132,7 +130,7 @@ export const createAnimalInsecure = cache(
 );
 
 // Secure database query for creating an animal by session token
-export const createAnimalBySessionToken = cache(
+export const createAnimal = cache(
   async (token: string, newAnimal: Omit<Animal, 'id'>) => {
     const [animal] = await sql<Animal[]>`
       INSERT INTO
@@ -179,7 +177,7 @@ export const updateAnimalByIdInsecure = cache(async (updatedAnimal: Animal) => {
 });
 
 // Secure database query for updating an animal by session token
-export const updateAnimalBySessionToken = cache(
+export const updateAnimal = cache(
   async (token: string, updatedAnimal: Animal) => {
     const [animal] = await sql<Animal[]>`
       UPDATE animals

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -20,7 +20,7 @@ import {
 // }
 
 // Secure database queries starts here
-// All queries not marked `Insecure` uses session tokens to authenticate the user
+// All queries not marked `Insecure` use session tokens to authenticate the user
 
 export const getAnimals = cache(async (token: string) => {
   const animals = await sql<Animal[]>`

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -58,7 +58,7 @@ export const createAnimal = cache(
             AND sessions.expiry_timestamp > now()
         )
       RETURNING
-        *
+        animals.*
     `;
 
     return animal;
@@ -227,7 +227,7 @@ export const createAnimalInsecure = cache(
           ${newAnimal.birthDate}
         )
       RETURNING
-        *
+        animals.*
     `;
 
     return animal;
@@ -245,7 +245,7 @@ export const updateAnimalInsecure = cache(async (updatedAnimal: Animal) => {
     WHERE
       id = ${updatedAnimal.id}
     RETURNING
-      *
+      animals.*
   `;
   return animal;
 });
@@ -256,7 +256,7 @@ export const deleteAnimalInsecure = cache(async (id: number) => {
     WHERE
       id = ${id}
     RETURNING
-      *
+      animals.*
   `;
 
   return animal;

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -15,7 +15,7 @@ import {
 //   { id: 5, firstName: 'Bili', type: 'Capybara', accessory: 'Pen' },
 // ];
 
-export const getAnimals = cache(async () => {
+export const getAnimalsInsecure = cache(async () => {
   // return animals;
   const animals = await sql<Animal[]>`
     SELECT
@@ -41,7 +41,7 @@ export const getAnimalsBySessionToken = cache(async (token: string) => {
   return animals;
 });
 
-export const getAnimalsWithLimitAndOffset = cache(
+export const getAnimalsWithLimitAndOffsetInsecure = cache(
   async (limit: number, offset: number) => {
     // return animals;
     const animals = await sql<Animal[]>`
@@ -58,7 +58,7 @@ export const getAnimalsWithLimitAndOffset = cache(
   },
 );
 
-export const getAnimalById = cache(async (id: number) => {
+export const getAnimalByIdInsecure = cache(async (id: number) => {
   // Postgres always returns an array
   const [animal] = await sql<Animal[]>`
     SELECT
@@ -214,7 +214,7 @@ export const updateAnimalBySessionToken = cache(
 // animalFoodType: string;
 
 // Join query for getting animal with related food/foods
-export const getAnimalsWithFoods = cache(async (id: number) => {
+export const getAnimalsWithFoodsInsecure = cache(async (id: number) => {
   const animalsFoods = await sql<AnimalFood[]>`
     SELECT
       animals.id AS animal_id,
@@ -235,7 +235,7 @@ export const getAnimalsWithFoods = cache(async (id: number) => {
 });
 
 // Join query for getting a single animal with related food/foods using Json_aag
-export const getAnimalWithFoodsById = cache(async (id: number) => {
+export const getAnimalWithFoodsByIdInsecure = cache(async (id: number) => {
   const [animal] = await sql<AnimalWithFoodsInJsonAgg[]>`
     SELECT
       animals.id AS animal_id,

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -72,7 +72,7 @@ export const getAnimalById = cache(async (id: number) => {
 });
 
 // Insecure database query for deleting an animal by id
-export const deleteAnimalByIdNaiveDontCopy = cache(async (id: number) => {
+export const deleteAnimalByIdInsecure = cache(async (id: number) => {
   const [animal] = await sql<Animal[]>`
     DELETE FROM animals
     WHERE
@@ -102,7 +102,7 @@ export const deleteAnimalBySessionToken = cache(
 );
 
 // Insecure database query for creating an animal by id
-export const createAnimalNaiveDontCopy = cache(
+export const createAnimalInsecure = cache(
   // Accept an object as an argument, allowing optional properties like
   // `accessory` before required properties like `birthDate`
   //
@@ -162,23 +162,21 @@ export const createAnimalBySessionToken = cache(
 );
 
 // Insecure database query for updating an animal by id
-export const updateAnimalByIdNaiveDontCopy = cache(
-  async (updatedAnimal: Animal) => {
-    const [animal] = await sql<Animal[]>`
-      UPDATE animals
-      SET
-        first_name = ${updatedAnimal.firstName},
-        type = ${updatedAnimal.type},
-        accessory = ${updatedAnimal.accessory},
-        birth_date = ${updatedAnimal.birthDate}
-      WHERE
-        id = ${updatedAnimal.id}
-      RETURNING
-        *
-    `;
-    return animal;
-  },
-);
+export const updateAnimalByIdInsecure = cache(async (updatedAnimal: Animal) => {
+  const [animal] = await sql<Animal[]>`
+    UPDATE animals
+    SET
+      first_name = ${updatedAnimal.firstName},
+      type = ${updatedAnimal.type},
+      accessory = ${updatedAnimal.accessory},
+      birth_date = ${updatedAnimal.birthDate}
+    WHERE
+      id = ${updatedAnimal.id}
+    RETURNING
+      *
+  `;
+  return animal;
+});
 
 // Secure database query for updating an animal by session token
 export const updateAnimalBySessionToken = cache(

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -117,8 +117,6 @@ export const createAnimalNaiveDontCopy = cache(
   },
 );
 
-// Secure database query for creating an animal by id
-
 // Insecure database query for updating an animal by id
 export const updateAnimalByIdNaiveDontCopy = cache(
   async (updatedAnimal: Animal) => {

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -20,7 +20,7 @@ import {
 // }
 
 // Secure database queries starts here
-// All queries without `Insecure` are protected by session tokens
+// All queries not marked `Insecure` uses session tokens to authenticate the user
 
 export const getAnimals = cache(async (token: string) => {
   const animals = await sql<Animal[]>`
@@ -102,7 +102,7 @@ export const deleteAnimal = cache(async (token: string, id: number) => {
 });
 
 // Insecure database queries starts here
-// All queries with `Insecure` are not protected by session tokens
+// All queries marked `Insecure` do not use session tokens to authenticate the user
 
 export const getAnimalsInsecure = cache(async () => {
   // return animals;

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -69,7 +69,7 @@ export const deleteAnimalByIdNaiveDontCopy = cache(async (id: number) => {
   return animal;
 });
 
-// Secure database query for deleting an animal by id
+// Secure database query for deleting an animal by session token
 export const deleteAnimalBySessionToken = cache(
   async (sessionToken: string, id: number) => {
     const [animal] = await sql<Animal[]>`
@@ -116,6 +116,8 @@ export const createAnimalNaiveDontCopy = cache(
     return animal;
   },
 );
+
+// Secure database query for creating an animal by id
 
 // Insecure database query for updating an animal by id
 export const updateAnimalByIdNaiveDontCopy = cache(

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -56,7 +56,8 @@ export const getAnimalById = cache(async (id: number) => {
   return animal;
 });
 
-export const deleteAnimalById = cache(async (id: number) => {
+// Insecure database query for deleting an animal by id
+export const deleteAnimalByIdNaiveDontCopy = cache(async (id: number) => {
   const [animal] = await sql<Animal[]>`
     DELETE FROM animals
     WHERE
@@ -86,7 +87,8 @@ export const deleteAnimalBySessionToken = cache(
   },
 );
 
-export const createAnimal = cache(
+// Insecure database query for creating an animal by id
+export const createAnimalNaiveDontCopy = cache(
   // Accept an object as an argument, allowing optional properties like
   // `accessory` before required properties like `birthDate`
   //
@@ -115,21 +117,24 @@ export const createAnimal = cache(
   },
 );
 
-export const updateAnimalById = cache(async (updatedAnimal: Animal) => {
-  const [animal] = await sql<Animal[]>`
-    UPDATE animals
-    SET
-      first_name = ${updatedAnimal.firstName},
-      type = ${updatedAnimal.type},
-      accessory = ${updatedAnimal.accessory},
-      birth_date = ${updatedAnimal.birthDate}
-    WHERE
-      id = ${updatedAnimal.id}
-    RETURNING
-      *
-  `;
-  return animal;
-});
+// Insecure database query for updating an animal by id
+export const updateAnimalByIdNaiveDontCopy = cache(
+  async (updatedAnimal: Animal) => {
+    const [animal] = await sql<Animal[]>`
+      UPDATE animals
+      SET
+        first_name = ${updatedAnimal.firstName},
+        type = ${updatedAnimal.type},
+        accessory = ${updatedAnimal.accessory},
+        birth_date = ${updatedAnimal.birthDate}
+      WHERE
+        id = ${updatedAnimal.id}
+      RETURNING
+        *
+    `;
+    return animal;
+  },
+);
 
 // export function getAnimal(id: number) {
 //   return animals1.find((animal) => animal.id === id);

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -68,6 +68,24 @@ export const deleteAnimalById = cache(async (id: number) => {
   return animal;
 });
 
+// Secure database query for deleting an animal by id
+export const deleteAnimalBySessionToken = cache(
+  async (sessionToken: string, id: number) => {
+    const [animal] = await sql<Animal[]>`
+      DELETE FROM animals USING sessions
+      INNER JOIN users ON sessions.user_id = users.id
+      WHERE
+        sessions.token = ${sessionToken}
+        AND sessions.expiry_timestamp > now()
+        AND animals.id = ${id}
+      RETURNING
+        animals.*
+    `;
+
+    return animal;
+  },
+);
+
 export const createAnimal = cache(
   // Accept an object as an argument, allowing optional properties like
   // `accessory` before required properties like `birthDate`

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -115,7 +115,7 @@ export const getAnimalsInsecure = cache(async () => {
   return animals;
 });
 
-export const getAnimalByIdInsecure = cache(async (id: number) => {
+export const getAnimalInsecure = cache(async (id: number) => {
   // Postgres always returns an array
   const [animal] = await sql<Animal[]>`
     SELECT
@@ -158,7 +158,7 @@ export const getAnimalsWithFoodsInsecure = cache(async (id: number) => {
 });
 
 // Join query for getting a single animal with related food/foods using Json_aag
-export const getAnimalWithFoodsByIdInsecure = cache(async (id: number) => {
+export const getAnimalWithFoodsInsecure = cache(async (id: number) => {
   const [animal] = await sql<AnimalWithFoodsInJsonAgg[]>`
     SELECT
       animals.id AS animal_id,
@@ -234,7 +234,7 @@ export const createAnimalInsecure = cache(
   },
 );
 
-export const updateAnimalByIdInsecure = cache(async (updatedAnimal: Animal) => {
+export const updateAnimalInsecure = cache(async (updatedAnimal: Animal) => {
   const [animal] = await sql<Animal[]>`
     UPDATE animals
     SET
@@ -250,7 +250,7 @@ export const updateAnimalByIdInsecure = cache(async (updatedAnimal: Animal) => {
   return animal;
 });
 
-export const deleteAnimalByIdInsecure = cache(async (id: number) => {
+export const deleteAnimalInsecure = cache(async (id: number) => {
   const [animal] = await sql<Animal[]>`
     DELETE FROM animals
     WHERE

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -19,7 +19,7 @@ import {
 //   return animals1.find((animal) => animal.id === id);
 // }
 
-// Secure database queries starts here
+// Secure database queries start here
 // All queries not marked `Insecure` use session tokens to authenticate the user
 
 export const getAnimals = cache(async (token: string) => {

--- a/database/notes.ts
+++ b/database/notes.ts
@@ -25,7 +25,7 @@ export const createNote = cache(
   },
 );
 
-export const getNotesBySessionToken = cache(async (token: string) => {
+export const getNotes = cache(async (token: string) => {
   const notes = await sql<Note[]>`
     SELECT
       notes.*
@@ -40,21 +40,19 @@ export const getNotesBySessionToken = cache(async (token: string) => {
   return notes;
 });
 
-export const getNoteBySessionToken = cache(
-  async (token: string, noteId: number) => {
-    const [note] = await sql<Note[]>`
-      SELECT
-        notes.*
-      FROM
-        notes
-        INNER JOIN sessions ON (
-          sessions.token = ${token}
-          AND notes.user_id = sessions.user_id
-          AND sessions.expiry_timestamp > now()
-        )
-      WHERE
-        notes.id = ${noteId}
-    `;
-    return note;
-  },
-);
+export const getNote = cache(async (token: string, noteId: number) => {
+  const [note] = await sql<Note[]>`
+    SELECT
+      notes.*
+    FROM
+      notes
+      INNER JOIN sessions ON (
+        sessions.token = ${token}
+        AND notes.user_id = sessions.user_id
+        AND sessions.expiry_timestamp > now()
+      )
+    WHERE
+      notes.id = ${noteId}
+  `;
+  return note;
+});

--- a/database/notes.ts
+++ b/database/notes.ts
@@ -2,29 +2,6 @@ import { cache } from 'react';
 import { Note } from '../migrations/00008-createTableNotes';
 import { sql } from './connect';
 
-export const createNote = cache(
-  async (token: string, title: string, textContent: string) => {
-    const [note] = await sql<Note[]>`
-      INSERT INTO
-        notes (user_id, title, text_content) (
-          SELECT
-            user_id,
-            ${title},
-            ${textContent}
-          FROM
-            sessions
-          WHERE
-            token = ${token}
-            AND sessions.expiry_timestamp > now()
-        )
-      RETURNING
-        *
-    `;
-
-    return note;
-  },
-);
-
 export const getNotes = cache(async (token: string) => {
   const notes = await sql<Note[]>`
     SELECT
@@ -56,3 +33,26 @@ export const getNote = cache(async (token: string, noteId: number) => {
   `;
   return note;
 });
+
+export const createNote = cache(
+  async (token: string, title: string, textContent: string) => {
+    const [note] = await sql<Note[]>`
+      INSERT INTO
+        notes (user_id, title, text_content) (
+          SELECT
+            user_id,
+            ${title},
+            ${textContent}
+          FROM
+            sessions
+          WHERE
+            token = ${token}
+            AND sessions.expiry_timestamp > now()
+        )
+      RETURNING
+        *
+    `;
+
+    return note;
+  },
+);

--- a/database/notes.ts
+++ b/database/notes.ts
@@ -50,7 +50,7 @@ export const createNote = cache(
             AND sessions.expiry_timestamp > now()
         )
       RETURNING
-        *
+        notes.*
     `;
 
     return note;

--- a/database/sessions.ts
+++ b/database/sessions.ts
@@ -2,6 +2,21 @@ import { cache } from 'react';
 import { sql } from '../database/connect';
 import { Session } from '../migrations/00007-createTableSessions';
 
+export const getValidSession = cache(async (token: string) => {
+  const [session] = await sql<Pick<Session, 'id' | 'token'>[]>`
+    SELECT
+      sessions.id,
+      sessions.token
+    FROM
+      sessions
+    WHERE
+      sessions.token = ${token}
+      AND sessions.expiry_timestamp > now()
+  `;
+
+  return session;
+});
+
 export const createSession = cache(async (userId: number, token: string) => {
   const [session] = await sql<Session[]>`
     INSERT INTO
@@ -36,21 +51,6 @@ export const deleteSession = cache(async (token: string) => {
     RETURNING
       id,
       token
-  `;
-
-  return session;
-});
-
-export const getValidSession = cache(async (token: string) => {
-  const [session] = await sql<Pick<Session, 'id' | 'token'>[]>`
-    SELECT
-      sessions.id,
-      sessions.token
-    FROM
-      sessions
-    WHERE
-      sessions.token = ${token}
-      AND sessions.expiry_timestamp > now()
   `;
 
   return session;

--- a/database/sessions.ts
+++ b/database/sessions.ts
@@ -30,7 +30,7 @@ export const createSession = cache(async (userId: number, token: string) => {
   return session;
 });
 
-export const deleteSessionByToken = cache(async (token: string) => {
+export const deleteSession = cache(async (token: string) => {
   // 'Pick' is a TS utility type that picks specified properties
   // from a type and excluding the rest
   const [session] = await sql<Pick<Session, 'id' | 'token'>[]>`
@@ -45,7 +45,7 @@ export const deleteSessionByToken = cache(async (token: string) => {
   return session;
 });
 
-export const getValidSessionByToken = cache(async (token: string) => {
+export const getValidSession = cache(async (token: string) => {
   const [session] = await sql<Pick<Session, 'id' | 'token'>[]>`
     SELECT
       sessions.id,

--- a/database/sessions.ts
+++ b/database/sessions.ts
@@ -2,14 +2,6 @@ import { cache } from 'react';
 import { sql } from '../database/connect';
 import { Session } from '../migrations/00007-createTableSessions';
 
-export const deleteExpiredSessions = cache(async () => {
-  await sql`
-    DELETE FROM sessions
-    WHERE
-      expiry_timestamp < now()
-  `;
-});
-
 export const createSession = cache(async (userId: number, token: string) => {
   const [session] = await sql<Session[]>`
     INSERT INTO
@@ -25,7 +17,11 @@ export const createSession = cache(async (userId: number, token: string) => {
       user_id
   `;
 
-  await deleteExpiredSessions();
+  await sql`
+    DELETE FROM sessions
+    WHERE
+      expiry_timestamp < now()
+  `;
 
   return session;
 });

--- a/database/sessions.ts
+++ b/database/sessions.ts
@@ -17,29 +17,31 @@ export const getValidSession = cache(async (token: string) => {
   return session;
 });
 
-export const createSession = cache(async (userId: number, token: string) => {
-  const [session] = await sql<Session[]>`
-    INSERT INTO
-      sessions (user_id, token)
-    VALUES
-      (
-        ${userId},
-        ${token}
-      )
-    RETURNING
-      id,
-      token,
-      user_id
-  `;
+export const createSessionInsecure = cache(
+  async (userId: number, token: string) => {
+    const [session] = await sql<Session[]>`
+      INSERT INTO
+        sessions (user_id, token)
+      VALUES
+        (
+          ${userId},
+          ${token}
+        )
+      RETURNING
+        id,
+        token,
+        user_id
+    `;
 
-  await sql`
-    DELETE FROM sessions
-    WHERE
-      expiry_timestamp < now()
-  `;
+    await sql`
+      DELETE FROM sessions
+      WHERE
+        expiry_timestamp < now()
+    `;
 
-  return session;
-});
+    return session;
+  },
+);
 
 export const deleteSession = cache(async (token: string) => {
   // 'Pick' is a TS utility type that picks specified properties

--- a/database/users.ts
+++ b/database/users.ts
@@ -6,7 +6,7 @@ export type UserWithPasswordHash = User & {
   passwordHash: string;
 };
 
-export const createUser = cache(
+export const createUserInsecure = cache(
   async (username: string, passwordHash: string) => {
     const [user] = await sql<User[]>`
       INSERT INTO
@@ -24,7 +24,7 @@ export const createUser = cache(
   },
 );
 
-export const getUserByUsername = cache(async (username: string) => {
+export const getUserByUsernameInsecure = cache(async (username: string) => {
   const [user] = await sql<User[]>`
     SELECT
       id,
@@ -37,7 +37,7 @@ export const getUserByUsername = cache(async (username: string) => {
   return user;
 });
 
-export const getUserWithPasswordHashByUsername = cache(
+export const getUserWithPasswordHashByUsernameInsecure = cache(
   async (username: string) => {
     const [user] = await sql<UserWithPasswordHash[]>`
       SELECT

--- a/database/users.ts
+++ b/database/users.ts
@@ -51,7 +51,7 @@ export const getUserWithPasswordHashByUsername = cache(
   },
 );
 
-export const getUserBySessionToken = cache(async (token: string) => {
+export const getUser = cache(async (token: string) => {
   const [user] = await sql<User[]>`
     SELECT
       users.id,

--- a/database/users.ts
+++ b/database/users.ts
@@ -6,23 +6,21 @@ export type UserWithPasswordHash = User & {
   passwordHash: string;
 };
 
-export const createUserInsecure = cache(
-  async (username: string, passwordHash: string) => {
-    const [user] = await sql<User[]>`
-      INSERT INTO
-        users (username, password_hash)
-      VALUES
-        (
-          ${username.toLowerCase()},
-          ${passwordHash}
-        )
-      RETURNING
-        id,
-        username
-    `;
-    return user;
-  },
-);
+export const getUser = cache(async (token: string) => {
+  const [user] = await sql<User[]>`
+    SELECT
+      users.id,
+      users.username
+    FROM
+      users
+      INNER JOIN sessions ON (
+        sessions.token = ${token}
+        AND sessions.user_id = users.id
+        AND sessions.expiry_timestamp > now()
+      )
+  `;
+  return user;
+});
 
 export const getUserByUsernameInsecure = cache(async (username: string) => {
   const [user] = await sql<User[]>`
@@ -51,18 +49,20 @@ export const getUserWithPasswordHashByUsernameInsecure = cache(
   },
 );
 
-export const getUser = cache(async (token: string) => {
-  const [user] = await sql<User[]>`
-    SELECT
-      users.id,
-      users.username
-    FROM
-      users
-      INNER JOIN sessions ON (
-        sessions.token = ${token}
-        AND sessions.user_id = users.id
-        AND sessions.expiry_timestamp > now()
-      )
-  `;
-  return user;
-});
+export const createUserInsecure = cache(
+  async (username: string, passwordHash: string) => {
+    const [user] = await sql<User[]>`
+      INSERT INTO
+        users (username, password_hash)
+      VALUES
+        (
+          ${username.toLowerCase()},
+          ${passwordHash}
+        )
+      RETURNING
+        id,
+        username
+    `;
+    return user;
+  },
+);


### PR DESCRIPTION
This PR makes all the database queries that are being used on the Animal dashboard and the remaining ones on the Note workflow secure by adding session token authentication to the query itself. This allows us to show the students a good practice of ensuring that the database queries are always secured and can be performed only by an allowed user

TODOs
- [x] Figure out the easy way to add the session token to the query without confusion
- [x] Change all the affected database queries to use the session token


Testing plans
- [x] CI passes